### PR TITLE
add theme toggle and toast form

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,11 @@ export default function RootLayout({
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet" />
         <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => { const t = localStorage.getItem('theme'); if (t === 'dark' || (!t && window.matchMedia('(prefers-color-scheme: dark)').matches)) { document.documentElement.classList.add('dark'); } })();`,
+          }}
+        />
       </head>
       <body className="font-body antialiased">
         {children}

--- a/src/components/landing-page.tsx
+++ b/src/components/landing-page.tsx
@@ -1,12 +1,28 @@
+"use client";
+
 import Link from "next/link";
 import { BarChart, Github, Sparkles, Rocket, Zap, TestTubes, TrendingUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { FadeIn } from "./fade-in";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { useToast } from "@/hooks/use-toast";
+import type { FormEvent } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 
 export function LandingPage() {
+  const { toast } = useToast();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    toast({
+      title: "¡Mensaje enviado!",
+      description: "Pronto nos comunicaremos contigo.",
+    });
+    e.currentTarget.reset();
+  };
+
   return (
     <div className="flex flex-col min-h-[100dvh] bg-background">
       <header className="container mx-auto px-4 sm:px-6 lg:px-8 h-20 flex items-center justify-between z-10">
@@ -14,6 +30,7 @@ export function LandingPage() {
           <Sparkles className="h-8 w-8 text-accent" />
           <span className="text-foreground">BrandBoost AI</span>
         </Link>
+        <ThemeToggle />
       </header>
 
       <main className="flex-1">
@@ -57,7 +74,7 @@ export function LandingPage() {
                     <CardDescription>Respuesta en 24 horas</CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <form className="space-y-4">
+                    <form onSubmit={handleSubmit} className="space-y-4">
                       <Input id="name" placeholder="Tu Nombre" />
                       <Input id="email" type="email" placeholder="Tu Correo Electrónico" />
                       <Input id="whatsapp" placeholder="WhatsApp" />

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useTheme } from "@/hooks/use-theme";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme}>
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}

--- a/src/hooks/use-theme.tsx
+++ b/src/hooks/use-theme.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem("theme") as Theme | null;
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initial = stored || (prefersDark ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    window.localStorage.setItem("theme", next);
+  };
+
+  return { theme, toggleTheme };
+}


### PR DESCRIPTION
## Summary
- add useTheme hook and ThemeToggle button for dark mode
- initialize theme from localStorage on page load
- improve landing page with ThemeToggle and toast-enabled form

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'next')*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef7e06ddc83288ddbc3e58956cbf4